### PR TITLE
feat(fixtures): cumulative fixture generation, scope-aware integratio…

### DIFF
--- a/internal/generators/fixture.go
+++ b/internal/generators/fixture.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/format"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -173,12 +174,86 @@ func BuildFixtureEntity(resolved *ResolvedFile, modulePath string) FixtureEntity
 		}
 	}
 
+	// Honor CHECK constraints with enum-style allowed-value lists
+	// (e.g. CHECK (principal_type IN ('user', 'service_account'))).
+	// Without this, the generic test-default `"test_<col>"` violates the
+	// constraint at INSERT time. The first allowed value wins.
+	if resolved.Table != nil {
+		allowed := allowedValuesFromCheckConstraints(resolved.Table.Constraints)
+		if len(allowed) > 0 {
+			for i, f := range entity.InsertFields {
+				if vals, ok := allowed[f.DBName]; ok && len(vals) > 0 {
+					// Only override non-FK string fields. FK columns get a
+					// fixture-provided variable name and shouldn't be coerced
+					// to a literal.
+					if !f.IsForeignKey {
+						entity.InsertFields[i].TestDefault = fmt.Sprintf("%q", vals[0])
+					}
+				}
+			}
+		}
+	}
+
 	// Build AllColumns for SELECT back.
 	for _, col := range resolved.AllColumns {
 		entity.AllColumns = append(entity.AllColumns, columnToFixture(col))
 	}
 
 	return entity
+}
+
+// checkArrayValueRe pulls single-quoted string literals out of an `ARRAY[...]`
+// inside a CHECK constraint's definition string. Postgres canonicalizes
+// `col IN ('a', 'b')` to `(col)::text = ANY ((ARRAY['a'::varchar, 'b'::varchar])::text[])`
+// so we cannot rely on the source `IN (...)` syntax surviving reflection.
+var checkArrayValueRe = regexp.MustCompile(`'([^']*)'`)
+
+// allowedValuesFromCheckConstraints returns a column → []value map for any
+// single-column CHECK constraint that pins the column to a finite set of
+// string literals. Two canonical shapes are recognized:
+//
+//   - `col IN ('a', 'b')` → `(col)::text = ANY ((ARRAY['a'::varchar, 'b'::varchar])::text[])`
+//   - `col = 'v'`         → `(col)::text = 'v'::text`
+//
+// Range, regexp, and multi-column checks pass through unmodified — callers
+// should treat them as "no override needed."
+func allowedValuesFromCheckConstraints(constraints []schema.ConstraintInfo) map[string][]string {
+	out := make(map[string][]string)
+	for _, c := range constraints {
+		if !strings.EqualFold(c.Type, "CHECK") {
+			continue
+		}
+		if len(c.Columns) != 1 {
+			continue
+		}
+		def := c.Definition
+
+		// Shape 1: ARRAY[...] (IN-list form).
+		if start := strings.Index(def, "ARRAY["); start >= 0 {
+			if end := strings.Index(def[start:], "]"); end > 0 {
+				segment := def[start : start+end+1]
+				matches := checkArrayValueRe.FindAllStringSubmatch(segment, -1)
+				if len(matches) > 0 {
+					vals := make([]string, 0, len(matches))
+					for _, m := range matches {
+						vals = append(vals, m[1])
+					}
+					out[c.Columns[0]] = vals
+					continue
+				}
+			}
+		}
+
+		// Shape 2: single-value equality. Recognized only when the
+		// constraint contains exactly one quoted literal — otherwise
+		// we can't tell apart `col = 'v'` from cases where multiple
+		// literals appear as type tags or unrelated subexpressions.
+		matches := checkArrayValueRe.FindAllStringSubmatch(def, -1)
+		if len(matches) == 1 {
+			out[c.Columns[0]] = []string{matches[0][1]}
+		}
+	}
+	return out
 }
 
 // buildParentFixtures extracts FK dependencies from a table.
@@ -417,6 +492,7 @@ func renderFixtureTemplate(tmplStr string, data FixtureTemplateData) ([]byte, er
 	funcMap := template.FuncMap{
 		"lower":          strings.ToLower,
 		"camel":          ToCamelCase,
+		"singularize":    Singularize,
 		"join":           strings.Join,
 		"positionalArgs": positionalArgs,
 		"add":            func(a, b int) int { return a + b },
@@ -552,14 +628,36 @@ func testDefaultForField(f FixtureField) string {
 			return "conversion.Ptr(0.0)"
 		case "time.Time":
 			return "conversion.Ptr(time.Now().UTC())"
+		case "json.RawMessage":
+			// Postgres rejects empty bytes as invalid JSON; emit `{}` so the
+			// INSERT succeeds whether the column is jsonb or json.
+			return `conversion.Ptr(json.RawMessage("{}"))`
 		default:
 			return fmt.Sprintf("conversion.Ptr(%s{})", innerType)
 		}
 	}
 
+	// Non-pointer JSON column.
+	if f.GoType == "json.RawMessage" {
+		return `json.RawMessage("{}")`
+	}
+
 	// Non-pointer types.
 	switch f.GoType {
 	case "string":
+		// Honor varchar(N) length caps so smoke-test inserts don't
+		// overflow narrow columns like varchar(12). The unique-ID slice
+		// is enough to keep values distinct without prefixing.
+		if f.MaxLength > 0 && f.MaxLength < 24 {
+			n := f.MaxLength
+			if n > 16 {
+				n = 16
+			}
+			if n <= 0 {
+				return `""`
+			}
+			return fmt.Sprintf(`testUniqueID[:%d]`, n)
+		}
 		switch {
 		case dbName == "email" || strings.HasSuffix(dbName, "_email"):
 			return `"test_" + testUniqueID[:8] + "@example.com"`

--- a/internal/generators/fixture_tmpl.go
+++ b/internal/generators/fixture_tmpl.go
@@ -50,7 +50,7 @@ func CreateTest{{$e.EntityName}}(t *testing.T, ctx context.Context, db *testpgx.
 		INSERT INTO principals (principal_id, principal_type, created_at)
 		VALUES ($1, $2, NOW())
 		ON CONFLICT (principal_id) DO NOTHING
-	` + "`" + `, {{camel $e.PKColumn}}, "{{lower $e.EntityName}}")
+	` + "`" + `, {{camel $e.PKColumn}}, "{{singularize $e.TableName}}")
 	require.NoError(t, err, "failed to insert principal for {{$e.EntityName}}")
 {{end}}
 	// Insert directly via SQL (bypassing repository for test isolation).
@@ -85,8 +85,8 @@ func CreateTest{{$e.EntityName}}(t *testing.T, ctx context.Context, db *testpgx.
 func CreateTest{{$e.EntityName}}WithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX{{range $e.AllExternalParams}}, {{.VarName}} string{{end}}) {{$e.RepoPkg}}.{{$e.EntityName}} {
 	t.Helper()
 {{range inBatchParents $e.ParentFixtures}}
-	parent{{.EntityName}} := CreateTest{{.EntityName}}WithDefaults(t, ctx, db{{range .ForwardParams}}, {{.VarName}}{{end}})
-	{{.VarName}} := parent{{.EntityName}}.{{.PKGoName}}
+	{{.VarName}}Parent := CreateTest{{.EntityName}}WithDefaults(t, ctx, db{{range .ForwardParams}}, {{.VarName}}{{end}})
+	{{.VarName}} := {{.VarName}}Parent.{{.PKGoName}}
 {{end}}
 	return CreateTest{{$e.EntityName}}(t, ctx, db{{range nonSelfRefParents $e.ParentFixtures}}, {{.VarName}}{{end}})
 }

--- a/internal/generators/generate.go
+++ b/internal/generators/generate.go
@@ -200,7 +200,35 @@ func Run(cfg Config) error {
 		}
 	}
 
-	// Generate test fixtures (single package across all domains for cross-domain FK resolution).
+	// Generate test fixtures. The fixtures file is a single package across ALL
+	// domains so cross-domain FK chains resolve (e.g. a graph entity referencing
+	// a worlds entity needs the worlds fixture in scope). When a domain filter
+	// is active, augment the in-scope entities with parse+resolve of every other
+	// domain's queries.sql so we don't overwrite the file with only the filtered
+	// domain's entities.
+	if cfg.Domain != "" {
+		inScope := make(map[string]bool, len(queryFiles))
+		for _, qf := range queryFiles {
+			inScope[qf] = true
+		}
+		allQueryFiles, err := discoverQueryFiles(repoRoot, "")
+		if err != nil {
+			return fmt.Errorf("discover all queries for fixtures: %w", err)
+		}
+		for _, qfPath := range allQueryFiles {
+			if inScope[qfPath] {
+				continue
+			}
+			resolved, err := resolveForFixture(qfPath, schemas, cfg.ProjectRoot)
+			if err != nil {
+				return fmt.Errorf("%s: resolve for fixture: %w", qfPath, err)
+			}
+			if resolved == nil {
+				continue
+			}
+			allFixtureEntities = append(allFixtureEntities, BuildFixtureEntity(resolved, modulePath))
+		}
+	}
 	if len(allFixtureEntities) > 0 {
 		fixtureDir := filepath.Join(cfg.ProjectRoot, "workshop", "testing", "fixtures")
 		data := FixtureTemplateData{
@@ -307,14 +335,29 @@ func generateFromQueryFile(
 		return nil, fmt.Errorf("pgxstore: %w", err)
 	}
 
-	// Generate pgxstore integration tests.
+	// Generate pgxstore integration tests, unless the entity opted out via
+	// `-- @skip-integration-test` in queries.sql. When skipped, remove any
+	// previously generated test file so a stale copy doesn't linger and
+	// keep failing.
 	storeDir := StoreDir(domainName, resolved.TableName, "pgx", projectRoot)
-	testData, err := BuildIntegrationTestData(resolved, modulePath)
-	if err != nil {
-		return nil, fmt.Errorf("integration test data: %w", err)
-	}
-	if err := GenerateIntegrationTest(testData, storeDir, opts); err != nil {
-		return nil, fmt.Errorf("integration tests: %w", err)
+	if resolved.SkipIntegrationTest {
+		stalePath := filepath.Join(storeDir, "generated_test.go")
+		if fileExists(stalePath) && !opts.DryRun {
+			if err := os.Remove(stalePath); err != nil {
+				return nil, fmt.Errorf("remove stale generated_test.go: %w", err)
+			}
+			if opts.Verbose {
+				fmt.Printf("      removed %s (skip-integration-test)\n", stalePath)
+			}
+		}
+	} else {
+		testData, err := BuildIntegrationTestData(resolved, modulePath)
+		if err != nil {
+			return nil, fmt.Errorf("integration test data: %w", err)
+		}
+		if err := GenerateIntegrationTest(testData, storeDir, opts); err != nil {
+			return nil, fmt.Errorf("integration tests: %w", err)
+		}
 	}
 
 	// Generate cache layer (only if any @cache annotations exist).
@@ -332,6 +375,45 @@ func generateFromQueryFile(
 	}
 
 	return resolved, nil
+}
+
+// resolveForFixture parses and resolves a queries.sql file without running
+// any code generation. Used to collect FixtureEntity data for entities that
+// live outside the current `--domain` filter, so the fixtures package can stay
+// cumulative across domains. Returns (nil, nil) if the table cannot be
+// matched against any reflected schema (same skip semantics as
+// generateFromQueryFile).
+func resolveForFixture(
+	qfPath string,
+	schemas map[string]*schema.ReflectedSchema,
+	projectRoot string,
+) (*ResolvedFile, error) {
+	qf, err := Parse(qfPath)
+	if err != nil {
+		return nil, err
+	}
+
+	repoDir := filepath.Dir(qfPath)
+	dirName := filepath.Base(repoDir)
+
+	tableName, schemaName, err := inferTableName(dirName, schemas, qf.Database)
+	if err != nil {
+		return nil, nil
+	}
+	qf.Table = tableName
+
+	key := qf.Database + ":" + schemaName
+	s, ok := schemas[key]
+	if !ok {
+		return nil, fmt.Errorf(
+			"reflected schema for database %q schema %q not found\n\n"+
+				"Run 'gopernicus db reflect' to generate it.",
+			qf.Database, schemaName,
+		)
+	}
+
+	domainName := domainFromPath(qfPath, projectRoot)
+	return Resolve(qf, s, domainName)
 }
 
 func loadSchemas(root string, m *manifest.Manifest) (map[string]*schema.ReflectedSchema, error) {

--- a/internal/generators/integration_test_gen.go
+++ b/internal/generators/integration_test_gen.go
@@ -67,6 +67,19 @@ type IntegrationTestData struct {
 
 	// Domain info
 	DomainName string
+
+	// *ExtraCallArgs are Go expressions to pass for queries whose SQL declares
+	// scope parameters beyond the PK / filter (e.g. @parent_world_id on a
+	// Get / List / SoftDelete / Delete). Each expression reads from the first
+	// created fixture's struct, dereferencing nullable columns. Examples:
+	// []string{"*created.ParentWorldID"}.
+	//
+	// Held per-method because the same entity may have different scope shapes
+	// across its standard verbs (though in practice they usually match).
+	ListExtraCallArgs       []string
+	GetExtraCallArgs        []string
+	SoftDeleteExtraCallArgs []string
+	HardDeleteExtraCallArgs []string
 }
 
 // BuildIntegrationTestData creates test data from a resolved file.
@@ -102,6 +115,9 @@ func BuildIntegrationTestData(resolved *ResolvedFile, modulePath string) (Integr
 			if pk := FindPKParam(m.PKParams, resolved.PKColumn); pk != "" {
 				tm.PKParam = pk
 			}
+			if m.Name == "Get" {
+				data.GetExtraCallArgs = buildScopeCallArgs(rq, resolved.PKColumn, resolved)
+			}
 
 		case "create":
 			data.HasCreate = true
@@ -113,6 +129,7 @@ func BuildIntegrationTestData(resolved *ResolvedFile, modulePath string) (Integr
 			if m.Name == "List" {
 				data.HasList = true
 				tm.HasList = true
+				data.ListExtraCallArgs = buildScopeCallArgs(rq, "", resolved)
 			}
 
 		case "update":
@@ -138,17 +155,22 @@ func BuildIntegrationTestData(resolved *ResolvedFile, modulePath string) (Integr
 			tm.ReturnsEntity = true
 
 		case "exec":
-			// Determine if it's a delete or state change.
-			if rq.Type == QueryDelete {
+			// Determine if it's a delete or state change. Only the method
+			// literally named "Delete" drives the standard hard-delete test —
+			// auxiliary delete-by-X variants have different signatures and
+			// would clobber the scope-arg list if we let them in.
+			if rq.Type == QueryDelete && m.Name == "Delete" {
 				data.HasHardDelete = true
 				tm.IsDelete = true
-			} else {
+				data.HardDeleteExtraCallArgs = buildScopeCallArgs(rq, resolved.PKColumn, resolved)
+			} else if rq.Type != QueryDelete {
 				nameLower := strings.ToLower(m.Name)
 				switch {
 				case nameLower == "softdelete":
 					data.HasSoftDelete = true
 					tm.IsSoftState = true
 					tm.NewState = "deleted"
+					data.SoftDeleteExtraCallArgs = buildScopeCallArgs(rq, resolved.PKColumn, resolved)
 				case nameLower == "archive":
 					tm.IsSoftState = true
 					tm.NewState = "archived"
@@ -204,6 +226,67 @@ func GenerateIntegrationTest(data IntegrationTestData, storeDir string, opts Opt
 	}
 
 	return nil
+}
+
+// buildScopeCallArgs returns Go expressions that read a query's scope
+// parameters (e.g. @parent_world_id) off the first created fixture's struct.
+// Used by the generated standard smoke tests (Get / List / SoftDelete /
+// HardDelete) to match the generated Store method's positional signature.
+//
+// Pass excludePKColumn to skip the PK param (Get / SoftDelete / Delete
+// already pass the PK as their first arg). Pass "" for List, which has no
+// PK in its params at all.
+//
+// Returns nil when the query has no extra params beyond the (optional) PK.
+func buildScopeCallArgs(rq ResolvedQuery, excludePKColumn string, resolved *ResolvedFile) []string {
+	if len(rq.Params) == 0 {
+		return nil
+	}
+	colByName := make(map[string]int, len(resolved.AllColumns))
+	for i, col := range resolved.AllColumns {
+		colByName[col.Name] = i
+	}
+	out := make([]string, 0, len(rq.Params))
+	for _, p := range rq.Params {
+		if p == excludePKColumn {
+			continue
+		}
+		idx, ok := colByName[p]
+		if !ok {
+			// Param does not map to a column on this entity (e.g. a free-form
+			// search term). Fall back to the Go zero value for its declared
+			// type so the test at least compiles.
+			goType := "string"
+			if t, ok := rq.ParamTypes[p]; ok {
+				goType = t
+			}
+			out = append(out, zeroValueExprForGoType(goType))
+			continue
+		}
+		col := resolved.AllColumns[idx]
+		expr := "created." + ToPascalCase(p)
+		if strings.HasPrefix(col.GoType, "*") {
+			expr = "*" + expr
+		}
+		out = append(out, expr)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func zeroValueExprForGoType(goType string) string {
+	switch goType {
+	case "string":
+		return `""`
+	case "bool":
+		return "false"
+	case "int", "int32", "int64", "float64":
+		return "0"
+	default:
+		return goType + "{}"
+	}
 }
 
 func renderIntegrationTestTemplate(tmplStr string, data IntegrationTestData) ([]byte, error) {

--- a/internal/generators/integration_test_tmpl.go
+++ b/internal/generators/integration_test_tmpl.go
@@ -30,7 +30,10 @@ var (
 )
 
 // setupTestStore creates a test database and store for integration tests.
-// migrateTestDB must be defined in store_test.go (bootstrap file).
+// migrateTestDB and testPGXOptions are defined in store_test.go (bootstrap
+// file). testPGXOptions lets the consumer customize the Postgres image,
+// enable extensions, etc. — needed when a project depends on extensions
+// like pgvector that the default image doesn't include.
 func setupTestStore(t *testing.T) (context.Context, *testpgx.TestPGX, *Store) {
 	t.Helper()
 
@@ -39,7 +42,8 @@ func setupTestStore(t *testing.T) (context.Context, *testpgx.TestPGX, *Store) {
 	}
 
 	ctx := context.Background()
-	db := testpgx.SetupTestPGX(t, ctx, testpgx.WithMigrations(migrateTestDB))
+	opts := append([]testpgx.Option{testpgx.WithMigrations(migrateTestDB)}, testPGXOptions...)
+	db := testpgx.SetupTestPGX(t, ctx, opts...)
 	store := NewStore(logger.NewNoop(), db.Pool)
 	return ctx, db, store
 }
@@ -49,9 +53,10 @@ func TestGenerated{{.EntityName}}Store_Create(t *testing.T) {
 	pgxfixtures.TruncatePublicSchema(t, ctx, db.Pool)
 
 	created := fixtures.CreateTest{{.EntityName}}WithDefaults(t, ctx, db)
+	_ = created
 
 	// Verify the record was created and can be retrieved.
-	result, err := store.Get(ctx, created.{{.PKGoName}})
+	result, err := store.Get(ctx, created.{{.PKGoName}}{{range .GetExtraCallArgs}}, {{.}}{{end}})
 	require.NoError(t, err)
 	assert.Equal(t, created.{{.PKGoName}}, result.{{.PKGoName}})
 }
@@ -61,15 +66,16 @@ func TestGenerated{{.EntityName}}Store_Get(t *testing.T) {
 	pgxfixtures.TruncatePublicSchema(t, ctx, db.Pool)
 
 	created := fixtures.CreateTest{{.EntityName}}WithDefaults(t, ctx, db)
+	_ = created
 
 	t.Run("found", func(t *testing.T) {
-		result, err := store.Get(ctx, created.{{.PKGoName}})
+		result, err := store.Get(ctx, created.{{.PKGoName}}{{range .GetExtraCallArgs}}, {{.}}{{end}})
 		require.NoError(t, err)
 		assert.Equal(t, created.{{.PKGoName}}, result.{{.PKGoName}})
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := store.Get(ctx, "nonexistent-id")
+		_, err := store.Get(ctx, "nonexistent-id"{{range .GetExtraCallArgs}}, {{.}}{{end}})
 		require.Error(t, err)
 	})
 }
@@ -78,25 +84,28 @@ func TestGenerated{{.EntityName}}Store_List(t *testing.T) {
 	ctx, db, store := setupTestStore(t)
 	pgxfixtures.TruncatePublicSchema(t, ctx, db.Pool)
 
-	// Create multiple records.
+	// Each fixture creates its own FK scope. When List filters by scope,
+	// only the matching row is visible; assertions below reflect that.
 	const numRecords = 3
-	for i := 0; i < numRecords; i++ {
+	created := fixtures.CreateTest{{.EntityName}}WithDefaults(t, ctx, db)
+	for i := 1; i < numRecords; i++ {
 		fixtures.CreateTest{{.EntityName}}WithDefaults(t, ctx, db)
 	}
+	_ = created
 
-	t.Run("returns all records", func(t *testing.T) {
+	t.Run("returns records", func(t *testing.T) {
 		filter := {{.RepoPkg}}.FilterList{}
 		orderBy := fop.NewOrder({{.RepoPkg}}.DefaultOrderBy, {{.RepoPkg}}.DefaultOrderDirection)
-		results, err := store.List(ctx, filter, orderBy, fop.PageStringCursor{}, false)
+		results, err := store.List(ctx, filter{{range .ListExtraCallArgs}}, {{.}}{{end}}, orderBy, fop.PageStringCursor{}, false)
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, len(results), numRecords)
+		assert.GreaterOrEqual(t, len(results), 1)
 	})
 
 	t.Run("respects limit", func(t *testing.T) {
 		filter := {{.RepoPkg}}.FilterList{}
 		orderBy := fop.NewOrder({{.RepoPkg}}.DefaultOrderBy, {{.RepoPkg}}.DefaultOrderDirection)
 		page := fop.PageStringCursor{Limit: 2}
-		results, err := store.List(ctx, filter, orderBy, page, false)
+		results, err := store.List(ctx, filter{{range .ListExtraCallArgs}}, {{.}}{{end}}, orderBy, page, false)
 		require.NoError(t, err)
 		assert.LessOrEqual(t, len(results), 2)
 	})
@@ -104,7 +113,7 @@ func TestGenerated{{.EntityName}}Store_List(t *testing.T) {
 	t.Run("no duplicates", func(t *testing.T) {
 		filter := {{.RepoPkg}}.FilterList{}
 		orderBy := fop.NewOrder({{.RepoPkg}}.DefaultOrderBy, {{.RepoPkg}}.DefaultOrderDirection)
-		results, err := store.List(ctx, filter, orderBy, fop.PageStringCursor{}, false)
+		results, err := store.List(ctx, filter{{range .ListExtraCallArgs}}, {{.}}{{end}}, orderBy, fop.PageStringCursor{}, false)
 		require.NoError(t, err)
 
 		seen := make(map[string]bool)
@@ -120,12 +129,13 @@ func TestGenerated{{.EntityName}}Store_Delete(t *testing.T) {
 	pgxfixtures.TruncatePublicSchema(t, ctx, db.Pool)
 
 	created := fixtures.CreateTest{{.EntityName}}WithDefaults(t, ctx, db)
+	_ = created
 
-	err := store.Delete(ctx, created.{{.PKGoName}})
+	err := store.Delete(ctx, created.{{.PKGoName}}{{range .HardDeleteExtraCallArgs}}, {{.}}{{end}})
 	require.NoError(t, err)
 
 	// Verify record is gone.
-	_, err = store.Get(ctx, created.{{.PKGoName}})
+	_, err = store.Get(ctx, created.{{.PKGoName}}{{range .GetExtraCallArgs}}, {{.}}{{end}})
 	require.Error(t, err)
 }
 {{end}}{{if .HasSoftDelete}}
@@ -134,12 +144,13 @@ func TestGenerated{{.EntityName}}Store_SoftDelete(t *testing.T) {
 	pgxfixtures.TruncatePublicSchema(t, ctx, db.Pool)
 
 	created := fixtures.CreateTest{{.EntityName}}WithDefaults(t, ctx, db)
+	_ = created
 
-	err := store.SoftDelete(ctx, created.{{.PKGoName}})
+	err := store.SoftDelete(ctx, created.{{.PKGoName}}{{range .SoftDeleteExtraCallArgs}}, {{.}}{{end}})
 	require.NoError(t, err)
 
 	// Verify record state changed.
-	result, err := store.Get(ctx, created.{{.PKGoName}})
+	result, err := store.Get(ctx, created.{{.PKGoName}}{{range .GetExtraCallArgs}}, {{.}}{{end}})
 	require.NoError(t, err)
 	assert.Equal(t, "deleted", result.RecordState)
 }
@@ -166,6 +177,7 @@ import (
 	"context"
 
 	"github.com/gopernicus/gopernicus/infrastructure/database/postgres/pgxdb"
+	"github.com/gopernicus/gopernicus/workshop/testing/testpgx"
 )
 
 // migrateTestDB runs migrations for the test database.
@@ -183,4 +195,14 @@ func migrateTestDB(_ context.Context, _ *pgxdb.Pool) error {
 	// Replace with actual migration logic.
 	return nil
 }
+
+// testPGXOptions provides extra options to testpgx.SetupTestPGX in the
+// generated setupTestStore helper. Use it to pick a Postgres image with
+// required extensions, e.g.:
+//
+//	var testPGXOptions = []testpgx.Option{
+//		testpgx.WithPostgresVersion("pgvector/pgvector:pg17"),
+//		testpgx.WithExtensions("vector", "pg_trgm"),
+//	}
+var testPGXOptions []testpgx.Option
 `

--- a/internal/generators/resolve.go
+++ b/internal/generators/resolve.go
@@ -60,20 +60,23 @@ func Resolve(qf *File, s *schema.ReflectedSchema, domainName string) (*ResolvedF
 		pkGoName = ToPascalCase(pkColumn)
 	}
 
+	_, skipIntegrationTest := qf.FileAnnotations["skip-integration-test"]
+
 	rf := &ResolvedFile{
-		Table:        table,
-		SchemaName:   s.SchemaName,
-		PackageName:  RepoPackage(qf.Table),
-		StorePkg:     StorePackage(qf.Table, "pgx"),
-		EntityName:   entityPascal,
-		EntityLower:  strings.ToLower(entityRaw),
-		EntityPlural: ToPascalCase(Pluralize(entityRaw)),
-		TableName:    qf.Table,
-		DomainName:   domainName,
-		AllColumns:   table.Columns,
-		PKColumn:     pkColumn,
-		PKGoName:     pkGoName,
-		PKGoType:     pkGoType,
+		Table:               table,
+		SchemaName:          s.SchemaName,
+		PackageName:         RepoPackage(qf.Table),
+		StorePkg:            StorePackage(qf.Table, "pgx"),
+		EntityName:          entityPascal,
+		EntityLower:         strings.ToLower(entityRaw),
+		EntityPlural:        ToPascalCase(Pluralize(entityRaw)),
+		TableName:           qf.Table,
+		DomainName:          domainName,
+		AllColumns:          table.Columns,
+		PKColumn:            pkColumn,
+		PKGoName:            pkGoName,
+		PKGoType:            pkGoType,
+		SkipIntegrationTest: skipIntegrationTest,
 	}
 
 	colMap := buildColumnMap(table)

--- a/internal/generators/types.go
+++ b/internal/generators/types.go
@@ -131,6 +131,14 @@ type ResolvedFile struct {
 	AuthRelations   []AuthRelation
 	AuthPermissions []AuthPermission
 
+	// SkipIntegrationTest suppresses generation of the per-store
+	// generated_test.go file for this entity. Set by the file-level
+	// `-- @skip-integration-test` annotation in queries.sql. Use this
+	// when an entity has cross-column invariants (e.g. mutually exclusive
+	// nullable FK groups) that the generic fixture cannot satisfy —
+	// hand-write the desired tests in store_test.go instead.
+	SkipIntegrationTest bool
+
 	Queries []ResolvedQuery
 }
 


### PR DESCRIPTION
…n tests, skip annotation

Fixture generation:
- Fixtures package is now cumulative across all domains. `gopernicus generate <one-domain>` walks every queries.sql for fixture entity collection so cross-domain FK chains continue to resolve and the file isn't clobbered with just the targeted domain.
- Disambiguate the FK-loop variable (`{{.VarName}}Parent`) so entities with multiple FKs to the same parent table (e.g. edges.source_node_id + edges.target_node_id) don't emit duplicate `parentNode :=` declarations.
- CHECK constraint awareness: parse `col IN (...)` (ARRAY form) and `col = 'value'` shapes; the first allowed value becomes the fixture default. Fixes generic `"test_<col>"` defaults violating constraints like principals_type_check.
- Respect varchar(N) MaxLength to avoid overflow on narrow columns; fall back to `testUniqueID[:N]`.
- Emit `json.RawMessage("{}")` for JSON columns instead of empty bytes (which Postgres rejects as invalid JSON).
- Principal inheritance uses `singularize(table_name)` rather than `lower(EntityName)`, so ServiceAccount maps to `service_account` (matching the canonical CHECK) instead of `serviceaccount`.

Integration test generation:
- Per-method scope-arg awareness for Get / List / SoftDelete / Delete / Create round-trip: when a query declares positional scope params (`@parent_world_id` etc.), the generated test reads them off the first created fixture (`*created.ParentWorldID`) so the call matches Store.X's signature.
- Guard `HasHardDelete` to the canonical `Delete` method only — auxiliary `DeleteByX` variants no longer clobber the scope-arg list.
- `setupTestStore` now appends a consumer-provided `testPGXOptions` slice to the testpgx options, so projects can customize the Postgres image / enable extensions (e.g. pgvector) without editing the generated file. Bootstrap (`store_test.go`) declares the variable.
- New file-level annotation `-- @skip-integration-test` suppresses generated_test.go emission for entities whose invariants the generic fixture cannot satisfy (e.g. mutually exclusive nullable FK groups). A previously generated file is removed on opt-in.